### PR TITLE
Change workflow permissions

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -5,6 +5,9 @@ on:
     branches: 
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Attempt to enable the docs publishing workflow to have the permissions it needs to write the docs site to the gh-pages branch