### PR TITLE
add Distribution to navigation menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
   - Model:
     - 'Data Service': DataService.md
     - Dataset: Dataset.md
+    - Distribution: Distribution.md
   - About: about.md
   - License: LICENSE.md
 site_url: https://co-cddo.github.io/data-catalogue-schemas


### PR DESCRIPTION
Adds a link to the Distribution page in the navigation menu in the model section