### PR TITLE
Make accessRights mandatory for Dataset and DataService

### DIFF
--- a/src/model/uk_cross_government_metadata_exchange_model.yaml
+++ b/src/model/uk_cross_government_metadata_exchange_model.yaml
@@ -86,6 +86,8 @@ classes:
       - theme
       - version
     slot_usage:
+      accessRights:
+        required: true
       description:
         required: true
       modified:


### PR DESCRIPTION
Fix #17 where it was identified that `accessRights` had not been correctly specified when moving from the google document version to the linkml model.